### PR TITLE
Enable instant viewing of summary confirmation page

### DIFF
--- a/pages/summary-confirmation.js
+++ b/pages/summary-confirmation.js
@@ -80,7 +80,7 @@ const ApplicationComplete = props => (
           </Paragraph>
         ) : null}
       </ContentItem.B_30_15>
-    ) : (
+    ) : props.lcConfig.hygiene && props.lcConfig.standards ? (
       <div>
         <ContentItem.B_30_15 id="hygieneCouncil">
           <Header level={4} mb={1}>
@@ -111,7 +111,7 @@ const ApplicationComplete = props => (
           <HintText>Responsible local council for food standards</HintText>
         </ContentItem.B_30_15>
       </div>
-    )}
+    ) : null}
 
     <ContentItem.B_30_15>
       <Paragraph className="receiveConfirmationEmail">

--- a/src/__tests__/summary-confirmation.test.js
+++ b/src/__tests__/summary-confirmation.test.js
@@ -207,4 +207,18 @@ describe("<ApplicationComplete />", () => {
       expect(panel.length).toBe(0);
     });
   });
+
+  describe("When given no lcConfig", () => {
+    it("The page still renders", () => {
+      const wrapper = mount(
+        <ApplicationComplete
+          cumulativeAnswers={cumulativeAnswers}
+          applicationCompletePage={true}
+          lcConfig={{}}
+          emailFbo={emailFbo}
+        />
+      );
+      expect(wrapper.length).toBe(1);
+    });
+  });
 });

--- a/src/server/controllers/continue.controller.test.js
+++ b/src/server/controllers/continue.controller.test.js
@@ -122,7 +122,6 @@ describe("Function: continueController: ", () => {
       );
     });
     it("Should return a response", () => {
-      console.log(response.cumulativeAnswers);
       expect(response.cumulativeAnswers.operator_first_name).toBe("name");
       expect(response.cumulativeAnswers.operator_secondary_number).toBe("");
     });


### PR DESCRIPTION
For some UI tests to be reduced in length to reach the confirmation page