### PR TITLE
Feature/config db additional logging

### DIFF
--- a/src/server/connectors/config-db/config-db.connector.js
+++ b/src/server/connectors/config-db/config-db.connector.js
@@ -102,13 +102,11 @@ const getPathConfigByVersion = async version => {
       throw newError;
     }
   }
-  const data = pathConfig ? `${Object.keys(pathConfig).length} paths found.` : "null";
 
   logEmitter.emit(
-    "functionSuccessWith",
+    "functionSuccess",
     "config-db.connector",
     "getPathConfigByVersion",
-    data
   );
 
   return pathConfig;
@@ -136,7 +134,7 @@ const getLocalCouncils = async () => {
       .project({ local_council_url: 1, _id: 0 })
       .toArray();
 
-    if (localCouncilUrls === null) {
+    if (localCouncilUrls.length < 1) {
       statusEmitter.emit("incrementCount", "getLocalCouncilsFailed");
       statusEmitter.emit(
         "setStatus",
@@ -172,13 +170,11 @@ const getLocalCouncils = async () => {
 
     throw newError;
   }
-  const data = localCouncilUrls ? `${localCouncilUrls.length} LA configurations found.` : "null";
 
   logEmitter.emit(
-    "functionSuccessWith",
+    "functionSuccess",
     "config-db.connector",
-    "getLocalCouncils",
-    data
+    "getLocalCouncils"
   );
 
   return localCouncilUrls;

--- a/src/server/connectors/config-db/config-db.connector.js
+++ b/src/server/connectors/config-db/config-db.connector.js
@@ -171,11 +171,7 @@ const getLocalCouncils = async () => {
     throw newError;
   }
 
-  logEmitter.emit(
-    "functionSuccess",
-    "config-db.connector",
-    "getLocalCouncils"
-  );
+  logEmitter.emit("functionSuccess", "config-db.connector", "getLocalCouncils");
 
   return localCouncilUrls;
 };

--- a/src/server/connectors/config-db/config-db.connector.js
+++ b/src/server/connectors/config-db/config-db.connector.js
@@ -106,7 +106,7 @@ const getPathConfigByVersion = async version => {
   logEmitter.emit(
     "functionSuccess",
     "config-db.connector",
-    "getPathConfigByVersion",
+    "getPathConfigByVersion"
   );
 
   return pathConfig;

--- a/src/server/connectors/config-db/config-db.connector.js
+++ b/src/server/connectors/config-db/config-db.connector.js
@@ -102,11 +102,13 @@ const getPathConfigByVersion = async version => {
       throw newError;
     }
   }
+  const data = pathConfig ? `${Object.keys(pathConfig).length} paths found.` : "null";
 
   logEmitter.emit(
-    "functionSuccess",
+    "functionSuccessWith",
     "config-db.connector",
-    "getPathConfigByVersion"
+    "getPathConfigByVersion",
+    data
   );
 
   return pathConfig;
@@ -170,6 +172,14 @@ const getLocalCouncils = async () => {
 
     throw newError;
   }
+  const data = localCouncilUrls ? `${localCouncilUrls.length} LA configurations found.` : "null";
+
+  logEmitter.emit(
+    "functionSuccessWith",
+    "config-db.connector",
+    "getLocalCouncils",
+    data
+  );
 
   return localCouncilUrls;
 };

--- a/src/server/connectors/config-db/config-db.connector.test.js
+++ b/src/server/connectors/config-db/config-db.connector.test.js
@@ -177,11 +177,16 @@ describe("Function: getLocalCouncils", () => {
           })
         })
       }));
-      result = await getLocalCouncils();
+      try {
+        await getLocalCouncils();
+      } catch (err) {
+        result = err;
+      }
     });
 
-    it("should return null", () => {
-      expect(result).toBe(null);
+    it("should throw mongoConnectionError error", () => {
+      expect(result.name).toBe("mongoConnectionError");
+      expect(result.message).toBe("Cannot read property 'length' of null");
     });
   });
 
@@ -214,6 +219,35 @@ describe("Function: getLocalCouncils", () => {
     });
 
     it("should return the array of councils", async () => {
+      await expect(getLocalCouncils()).resolves.toEqual(localCouncilsMock);
+    });
+  });
+
+  describe("given there are no lc configuration records", () => {
+    const localCouncilsObjs = [];
+    const localCouncilsMock = [];
+
+    const mongoCursor = {
+      project: () => {
+        return {
+          toArray: () => {
+            return localCouncilsObjs;
+          }
+        };
+      }
+    };
+
+    beforeEach(() => {
+      mongodb.MongoClient.connect.mockImplementation(() => ({
+        db: () => ({
+          collection: () => ({
+            find: () => mongoCursor
+          })
+        })
+      }));
+    });
+
+    it("should return an empty array and not throw an exception", async () => {
       await expect(getLocalCouncils()).resolves.toEqual(localCouncilsMock);
     });
   });


### PR DESCRIPTION
-Log getLocalCouncils function success
-Fail immediately if the value of LC configurations retrieved from database is not a non-empty array