### PR TITLE
fix edit partner bug

### DIFF
--- a/src/server/routes/partner-details.route.js
+++ b/src/server/routes/partner-details.route.js
@@ -85,6 +85,8 @@ const partnerDetailsRouter = () => {
     const targetPartner = parseInt(req.query.id, 10);
     if (!isNaN(targetPartner)) {
       req.session.cumulativeFullAnswers.targetPartner = targetPartner;
+    } else {
+      delete req.session.cumulativeFullAnswers.targetPartner;
     }
 
     logEmitter.emit(

--- a/src/server/routes/partner-details.route.test.js
+++ b/src/server/routes/partner-details.route.test.js
@@ -296,12 +296,42 @@ describe("Partner Details Route: ", () => {
       });
 
       it("Should delete target partner", () => {
-        expect(req.session.cumulativeFullAnswers.targetPartner).toEqual(
-          undefined
-        );
+        expect(req.session.cumulativeFullAnswers.targetPartner).toBe(undefined);
       });
       it("Should have Partners as an empty array", () => {
         expect(req.session.cumulativeFullAnswers.partners).toEqual([]);
+      });
+      it("Should call Next.render", () => {
+        expect(Next.render).toBeCalled();
+      });
+    });
+
+    describe("When targetPartner is set in session but req param is missing", () => {
+      let res, req;
+      beforeEach(() => {
+        handler = router.get.mock.calls[0][1];
+
+        req = {
+          session: {
+            cumulativeFullAnswers: {
+              targetPartner: "Brian",
+              partners: ["Brian"]
+            },
+            save: cb => {
+              cb();
+            }
+          },
+          query: {}
+        };
+
+        res = {
+          redirect: jest.fn()
+        };
+
+        handler(req, res);
+      });
+      it("Should delete target partner", () => {
+        expect(req.session.cumulativeFullAnswers.targetPartner).toBe(undefined);
       });
       it("Should call Next.render", () => {
         expect(Next.render).toBeCalled();


### PR DESCRIPTION
- Clear targetPartner when the user's action is adding, not editing
- Add unit test to prove the bug is fixed