### PR TITLE
bugfix/unsupported-browsers-on-error-pages

### DIFF
--- a/src/components/FsaLayout.js
+++ b/src/components/FsaLayout.js
@@ -21,7 +21,7 @@ const FsaLayout = props => (
     <Page header={<FsaHeader {...props} />}>
       <GridRowZeroMargin>
         <GridColZeroPadding columnTwoThirds>
-          {!props.isBrowserSupported ? (
+          {props.isBrowserSupported === false ? (
             <BrowserUnsupportedBanner
               browser={props.browser}
               version={props.browserVersion}

--- a/src/components/SessionWrapper.js
+++ b/src/components/SessionWrapper.js
@@ -110,7 +110,7 @@ const SessionWrapper = Page => {
       isBrowserSupported:
         req && req.session && req.session.isBrowserSupported
           ? req.session.isBrowserSupported
-          : false,
+          : undefined,
       browser:
         req && req.session && req.session.browser ? req.session.browser : "",
       browserVersion:

--- a/src/components/SessionWrapper.test.js
+++ b/src/components/SessionWrapper.test.js
@@ -22,7 +22,6 @@ const comprehensiveReqSessionObject = {
     lcConfig: { example: "data" },
     council: "cardiff",
     addressLookups: { test: [] },
-    isBrowserSupported: true,
     browser: "Chrome",
     browserVersion: "70.1.12"
   }


### PR DESCRIPTION
- Fix bug caused by "isBrowserSupported" flag being initialised to false (indicating unsupported) instead of undefined (indicating not yet verified)