### PR TITLE
Fix postcode responses

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -9,7 +9,7 @@ module.exports = {
   ADDRESS_API_URL_BASE:
     "http://ws.postcoder.com/pcw/" +
     (process.env.ADDRESS_API_KEY || "PCW45-12345-12345-1234X") +
-    "/addressbase/dpa/",
+    "/addressbase/dpa",
   ADDRESS_API_URL_QUERY: "format=json&lines=4&addtags=uprn",
   API_SECRET: process.env.API_SECRET,
   CLIENT_NAME: process.env.CLIENT_NAME,

--- a/src/server/connectors/address-lookup/address-lookup-api.connector.js
+++ b/src/server/connectors/address-lookup/address-lookup-api.connector.js
@@ -16,11 +16,7 @@ const { addressLookupDouble } = require("./address-lookup-api.double");
  *
  * @returns {array} A list of addresses
  */
-const getAddressesByPostcode = async (
-  country,
-  postcode,
-  addressCountLimit = 100
-) => {
+const getAddressesByPostcode = async (postcode, addressCountLimit = 100) => {
   logEmitter.emit(
     "functionCallWith",
     "address-lookup-api.connector",
@@ -30,19 +26,13 @@ const getAddressesByPostcode = async (
 
   const DOUBLE_MODE = process.env.DOUBLE_MODE;
 
-  const lowercaseCountryCode = country.toLowerCase();
-
   let firstRes;
   let firstJson;
   if (DOUBLE_MODE === "true") {
-    firstRes = addressLookupDouble(
-      lowercaseCountryCode,
-      postcode,
-      ADDRESS_API_URL_QUERY
-    );
+    firstRes = addressLookupDouble(postcode, ADDRESS_API_URL_QUERY);
   } else {
     firstRes = await fetch(
-      `${ADDRESS_API_URL_BASE}/${lowercaseCountryCode}/${postcode}?${ADDRESS_API_URL_QUERY}`,
+      `${ADDRESS_API_URL_BASE}/${postcode}?${ADDRESS_API_URL_QUERY}`,
       {
         method: "GET"
       }

--- a/src/server/connectors/address-lookup/address-lookup-api.double.js
+++ b/src/server/connectors/address-lookup/address-lookup-api.double.js
@@ -1,24 +1,20 @@
 const regularIntegrationResponse = require("./regularIntegrationResponse.json");
 
-const addressLookupDouble = (countryCode, postcode, query) => {
-  if (countryCode === "uk") {
-    if (postcode === "BS249ST") {
-      return { json: () => regularIntegrationResponse, status: 200 };
-    } else if (postcode === "AA111AA") {
-      return { json: () => [], status: 200 };
-      // TODO JMB - double for long responses. Requires testing.
-      // } else if(postcode === "ADD > 100 ADDRESS POSTCODE HERE") {
-      //   if(query === "?format=json&lines=4") {
-      //     return "ADD FULL LENGTH RESPONSE HERE"
-      //   }
-      //   else if(query === "?format=json&lines=4&page=2") {
-      //     return "ADD PAGE 2 OF FULL LENGTH RESPONSE HERE"
-      //   }
-      //   else return {status: 500};
-    } else return { status: 500 };
-  } else {
-    return { status: 404 };
-  }
+const addressLookupDouble = (postcode, query) => {
+  if (postcode === "BS249ST") {
+    return { json: () => regularIntegrationResponse, status: 200 };
+  } else if (postcode === "AA111AA") {
+    return { json: () => [], status: 200 };
+    // TODO JMB - double for long responses. Requires testing.
+    // } else if(postcode === "ADD > 100 ADDRESS POSTCODE HERE") {
+    //   if(query === "?format=json&lines=4") {
+    //     return "ADD FULL LENGTH RESPONSE HERE"
+    //   }
+    //   else if(query === "?format=json&lines=4&page=2") {
+    //     return "ADD PAGE 2 OF FULL LENGTH RESPONSE HERE"
+    //   }
+    //   else return {status: 500};
+  } else return { status: 500 };
 };
 
 module.exports = { addressLookupDouble };

--- a/src/server/services/address.service.js
+++ b/src/server/services/address.service.js
@@ -24,11 +24,7 @@ const getUkAddressesByPostcode = async postcode => {
   );
 
   try {
-    const addressLookupResponse = await getAddressesByPostcode(
-      "uk",
-      postcode,
-      500
-    );
+    const addressLookupResponse = await getAddressesByPostcode(postcode, 500);
 
     statusEmitter.emit("setStatus", "mostRecentAddressLookupSucceeded", true);
     logEmitter.emit(

--- a/src/server/services/address.service.test.js
+++ b/src/server/services/address.service.test.js
@@ -32,11 +32,7 @@ describe("address.service getUkAddressesByPostcode()", () => {
     });
 
     it("calls getAddressesByPostcode with 'uk', a postcode, and a address limit of 500", () => {
-      expect(getAddressesByPostcode).toHaveBeenCalledWith(
-        "uk",
-        "NR14 7PZ",
-        500
-      );
+      expect(getAddressesByPostcode).toHaveBeenCalledWith("NR14 7PZ", 500);
     });
   });
 

--- a/tests/integration/address-lookup.integration.test.js
+++ b/tests/integration/address-lookup.integration.test.js
@@ -9,7 +9,7 @@ describe("Address lookup API service", () => {
 
   describe("When given a valid request", () => {
     beforeEach(async () => {
-      response = await getAddressesByPostcode("uk", "BS249ST", 100);
+      response = await getAddressesByPostcode("BS249ST", 100);
     });
 
     describe("an entry in json function array", () => {
@@ -24,7 +24,7 @@ describe("Address lookup API service", () => {
 
   describe("When given a valid request that returns no addresses", () => {
     beforeEach(async () => {
-      response = await getAddressesByPostcode("uk", "AA111AA", 100);
+      response = await getAddressesByPostcode("AA111AA", 100);
     });
 
     it("should return an empty array", () => {
@@ -36,7 +36,7 @@ describe("Address lookup API service", () => {
     it("should throw an error", async () => {
       let result;
       try {
-        await getAddressesByPostcode("uk", "Not a handled postcode", 100);
+        await getAddressesByPostcode("Not a handled postcode", 100);
       } catch (err) {
         result = err;
       }


### PR DESCRIPTION
Remove UK from the URL as this appears to form an additional filter on the premium postcoder API calls which was returning extra or removing results from the response