### PR TITLE
Fix broken ssr styles with emotion, styled-components and inline styl…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.next/*
+.vscode/*

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "jsdoc": "rm -rf ./docs/jsdoc && jsdoc -r ./src -d ./docs/jsdoc",
     "updateBusinessTypes": "node ./src/components/update-business-types.js && yarn format"
   },
+  "resolutions": {
+    "styled-components": "^5.1.0"
+  },
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
@@ -67,13 +70,17 @@
     "react-is": "^16.13.1",
     "react-markdown": "^4.3.1",
     "stemmer": "^1.0.5",
-    "styled-components": "4",
+    "styled-components": "^5.1.0",
     "validator": "^13.0.0",
     "winston": "2.4.2"
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
+    "@babel/plugin-transform-react-jsx": "^7.9.4",
+    "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/preset-env": "^7.9.5",
+    "@babel/preset-react": "^7.9.4",
     "@storybook/addons": "^5.3.18",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "2.x",
@@ -116,12 +123,8 @@
       }
     },
     "plugins": [
-      [
-        "emotion",
-        {
-          "inline": true
-        }
-      ],
+      "babel-plugin-styled-components",
+      "@babel/plugin-transform-runtime",
       "inline-react-svg"
     ],
     "presets": [
@@ -129,6 +132,7 @@
         "@babel/preset-env",
         {
           "targets": {
+            "node": "12",
             "edge": "16",
             "firefox": "60",
             "chrome": "67",
@@ -141,6 +145,7 @@
           "useBuiltIns": "entry"
         }
       ],
+      "@babel/preset-react",
       "next/babel"
     ]
   },

--- a/pages/summary-confirmation.js
+++ b/pages/summary-confirmation.js
@@ -30,9 +30,9 @@ const ApplicationComplete = (props) => (
       <FsaPanel id="panelWithNumber" title="">
         {[
           "Your unique food business registration application reference is",
-          <br />,
-          <br />,
-          <span className="bold" id="fsa-rn">
+          <br key={1} />,
+          <br key={2} />,
+          <span key={3} className="bold" id="fsa-rn">
             {props.fsaRegistrationNumber.split("-").join(" - ")}
           </span>
         ]}

--- a/src/components/ContinueButton.test.js
+++ b/src/components/ContinueButton.test.js
@@ -25,7 +25,7 @@ describe("<ContinueButton />", () => {
 
   it("passes the prop 'start' as 'false' by default for the Button component", () => {
     const wrapper = mount(<ContinueButton />);
-    const GovUkButton = wrapper.find("StyledComponent");
+    const GovUkButton = wrapper.find("#continue-button").at(1);
     expect(GovUkButton.props().isStart).toBe(false);
   });
 
@@ -45,7 +45,7 @@ describe("<ContinueButton />", () => {
     });
 
     it("passes the prop 'start' as 'true' for the Button component", () => {
-      const GovUkButton = wrapper.find("StyledComponent").at(0);
+      const GovUkButton = wrapper.find("#continue-button").at(1);
       expect(GovUkButton.props().isStart).toBe(true);
     });
 

--- a/src/components/FsaLayout.js
+++ b/src/components/FsaLayout.js
@@ -5,6 +5,9 @@ import styled from "@emotion/styled";
 import React from "react";
 import { MEDIA_QUERIES } from "@govuk-react/constants";
 import BrowserUnsupportedBanner from "./BrowserUnsupportedBanner";
+import AccessibleAutocompleteCSS from "./AccessibleAutocompleteCSS";
+import NormalizeCSS from "./NormalizeCSS";
+import { Global } from "@emotion/core";
 
 const GridRowZeroMargin = styled(GridRow)`
   margin: 0px;
@@ -18,6 +21,8 @@ const GridColZeroPadding = styled(GridCol)`
 
 const FsaLayout = (props) => (
   <React.Fragment>
+    <Global styles={AccessibleAutocompleteCSS} />
+    <Global styles={NormalizeCSS} />
     <Page header={<FsaHeader {...props} />}>
       <GridRowZeroMargin>
         <GridColZeroPadding setWidth="two-thirds">

--- a/src/components/HiddenTextAccessible.js
+++ b/src/components/HiddenTextAccessible.js
@@ -1,4 +1,4 @@
-import { VisuallyHidden } from "govuk-react";
+import { Details } from "govuk-react";
 import PropTypes from "prop-types";
 import { ContentItem } from "./";
 // import InvisibleLink from "./InvisibleLink";
@@ -10,16 +10,9 @@ import { ContentItem } from "./";
 
 const HiddenTextAccessible = (props) => (
   <ContentItem.B_30_15>
-    <VisuallyHidden mb={0} aria-label="Additional information" {...props}>
-      {/* <InvisibleLink href={`#skipAdditionalInfo_${props.hiddentextindex}`}>
-    Skip this additional information
-  </InvisibleLink> */}
+    <Details summary={`Additional Information`} {...props}>
       {props.children}
-      {/* <div
-    aria-hidden="true"
-    id={`skipAdditionalInfo_${props.hiddentextindex}`}
-  /> */}
-    </VisuallyHidden>
+    </Details>
   </ContentItem.B_30_15>
 );
 


### PR DESCRIPTION
…es. Fix missing babel.

This is the fresh cleaned up branch direct from latest develop I mentioned earlier.

Local testing of ui with my prototype docker selenium ui tests yield this consistent failure:

[chrome  linux #0-14]
[chrome  linux #0-14] 1) Deleting partner And I expect that element "#continue-button" does appear exactly "1" times
[chrome  linux #0-14] expect(received).toHaveLength(expected)

Matcher error: expected value must be a non-negative integer

Expected has type:  string
Expected has value: "1"
[chrome  linux #0-14] Error: expect(received).toHaveLength(expected)
[chrome  linux #0-14]
[chrome  linux #0-14] Matcher error: expected value must be a non-negative integer
[chrome  linux #0-14]
[chrome  linux #0-14] Expected has type:  string
[chrome  linux #0-14] Expected has value: "1"
[chrome  linux #0-14]     at World._default (/usr/src/app/src/support/lib/checkIfElementExists.js:23:30)
[chrome  linux #0-14]
[chrome  linux #0-14] 2) no selection on main-partnership-contact Then I expect that element "mainPartnershipContact.partnerOne" contains the text "one"
[chrome  linux #0-14] function timed out, ensure the promise resolves within 10000 milliseconds
[chrome  linux #0-14] Error: function timed out, ensure the promise resolves within 10000 milliseconds
[chrome  linux #0-14]     at Timeout._onTimeout (/usr/src/app/node_modules/cucumber/lib/user_code_runner.js:76:18)
[chrome  linux #0-14]     at listOnTimeout (internal/timers.js:531:17)
[chrome  linux #0-14]     at processTimers (internal/timers.js:475:7)


Spec Files:	 34 passed, 2 retries, 1 failed, 35 total (100% completed) in 00:11:29 

