### PR TITLE
Accessibility - Incorrect Behaviour of Details Element

### DIFF
--- a/pages/business-import-export.js
+++ b/pages/business-import-export.js
@@ -79,6 +79,7 @@ const ImportExportActivities = (props) => (
           summary={props.t(
             "More information about import and export activities"
           )}
+          {...props}
         >
           <span>
             {props.t(

--- a/pages/business-water-supply.js
+++ b/pages/business-water-supply.js
@@ -29,7 +29,10 @@ const WaterSupply = (props) => (
           >
             {props.t("What type of water supply does this establishment use?")}
           </Fieldset.Legend>
-          <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+          <HiddenTextAccessible
+            summary={props.t("What is an establishment?")}
+            {...props}
+          >
             <Paragraph mb={0}>
               {props.t(
                 "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."
@@ -90,6 +93,7 @@ const WaterSupply = (props) => (
         <HiddenTextAccessible
           id="hiddenTextWaterSupply"
           summary={props.t("I don't know if I have a private water supply")}
+          {...props}
         >
           <span>
             {props.t(

--- a/pages/contact-representative.js
+++ b/pages/contact-representative.js
@@ -29,6 +29,7 @@ const ContactRepresentative = (props) => {
       </Paragraph>
       <HiddenTextAccessible
         summary={props.t("What is a food business operator?")}
+        {...props}
       >
         <Paragraph mb={0}>
           {props.t(

--- a/pages/establishment-address-manual.js
+++ b/pages/establishment-address-manual.js
@@ -29,7 +29,10 @@ const EstablishmentAddress = (props) => (
       {props.t("What is the establishment's address?")}
     </Heading>
 
-    <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+    <HiddenTextAccessible
+      summary={props.t("What is an establishment?")}
+      {...props}
+    >
       <Paragraph mb={0}>
         {props.t(
           "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/establishment-address-select.js
+++ b/pages/establishment-address-select.js
@@ -20,6 +20,7 @@ const EstablishmentAddressLookup = (props) => (
     <HiddenTextAccessible
       id="hiddenTextEstablishment"
       summary={props.t("What is an establishment?")}
+      {...props}
     >
       <Paragraph mb={0}>
         {props.t(

--- a/pages/establishment-address-type.js
+++ b/pages/establishment-address-type.js
@@ -29,7 +29,10 @@ const EstablishmentAddressType = (props) => (
           >
             {props.t("Where is this establishment located?")}
           </Fieldset.Legend>
-          <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+          <HiddenTextAccessible
+            summary={props.t("What is an establishment?")}
+            {...props}
+          >
             <Paragraph mb={0}>
               {props.t(
                 "An establishment is the location of your food business. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/establishment-address.js
+++ b/pages/establishment-address.js
@@ -22,7 +22,10 @@ const EstablishmentAddress = (props) => (
       {props.t("Establishment address")}
     </Heading>
 
-    <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+    <HiddenTextAccessible
+      summary={props.t("What is an establishment?")}
+      {...props}
+    >
       <Paragraph mb={0}>
         {props.t(
           "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/establishment-contact-details.js
+++ b/pages/establishment-contact-details.js
@@ -22,7 +22,10 @@ const EstablishmentContactDetails = (props) => (
     <Heading as="h1" size="LARGE">
       {props.t("Establishment contact details")}
     </Heading>
-    <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+    <HiddenTextAccessible
+      summary={props.t("What is an establishment?")}
+      {...props}
+    >
       <Paragraph mb={0}>
         {props.t(
           "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/establishment-opening-status.js
+++ b/pages/establishment-opening-status.js
@@ -35,7 +35,10 @@ const EstablishmentOpeningStatus = (props) => (
               )}
             </HintText>
           </ContentItem.B_30_15>
-          <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+          <HiddenTextAccessible
+            summary={props.t("What is an establishment?")}
+            {...props}
+          >
             <Paragraph mb={0}>
               {props.t(
                 "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/establishment-trading-name.js
+++ b/pages/establishment-trading-name.js
@@ -22,7 +22,10 @@ const EstablishmentTradingName = (props) => (
       {props.t("Trading name")}
     </Heading>
 
-    <HiddenTextAccessible summary={props.t("What is an establishment?")}>
+    <HiddenTextAccessible
+      summary={props.t("What is an establishment?")}
+      {...props}
+    >
       <Paragraph mb={0}>
         {props.t(
           "An establishment is the location of your food business, and the food activities taking place there. If it is a mobile food business, please use the location where it is normally stored overnight."

--- a/pages/main-partnership-contact.js
+++ b/pages/main-partnership-contact.js
@@ -58,7 +58,7 @@ const PrimaryPartner = (props) => (
               )}
             </HintText>
           </ContentItem.B_30_15>
-          <PartnershipDescription />
+          <PartnershipDescription {...props} />
           <MultiChoice
             label=""
             meta={{

--- a/pages/opening-days-start.js
+++ b/pages/opening-days-start.js
@@ -73,6 +73,7 @@ const OpeningDaysStart = (props) => (
       </ContentItem.B_30_15>
       <HiddenTextAccessible
         summary={props.t("I don't know what days to select")}
+        {...props}
       >
         <Paragraph mb={0}>
           {props.t(

--- a/pages/operator-charity-details.js
+++ b/pages/operator-charity-details.js
@@ -26,6 +26,7 @@ const OperatorCharityDetails = (props) => (
       hiddentextindex={1}
       id="hiddenTextFBO"
       summary={props.t("What is a food business operator?")}
+      {...props}
     >
       <Paragraph mb={0}>
         {props.t(
@@ -74,6 +75,7 @@ const OperatorCharityDetails = (props) => (
           hiddentextindex={2}
           id="hiddenTextCharityNumbers"
           summary={props.t("Questions about charity reference numbers")}
+          {...props}
         >
           <span>
             {props.t(

--- a/pages/operator-company-details.js
+++ b/pages/operator-company-details.js
@@ -65,6 +65,7 @@ const LimitedCompanyDetails = (props) => (
       <ContentItem.B_30_15>
         <HiddenTextAccessible
           summary={props.t("I don't know my Companies House number")}
+          {...props}
         >
           {/* TODO JMB: replace the span with a paragraph once it's possible to pass an array or similar to Paragraph for the link */}
           <span>

--- a/pages/operator-contact-details.js
+++ b/pages/operator-contact-details.js
@@ -29,7 +29,10 @@ const OperatorContactDetails = (props) => (
         } contact details`
       )}
     </Heading>
-    <ContactDetailsHelp role={props.cumulativeFullAnswers.registration_role} />
+    <ContactDetailsHelp
+      role={props.cumulativeFullAnswers.registration_role}
+      {...props}
+    />
     <PostForm action={props.formAction} csrfToken={props.csrfToken}>
       <ContentItem.B_30_15>
         <ContentItem.B_30_15>

--- a/pages/operator-name.js
+++ b/pages/operator-name.js
@@ -23,6 +23,7 @@ const OperatorName = (props) => (
     </Heading>
     <HiddenTextAccessible
       summary={props.t("What is a food business operator?")}
+      {...props}
     >
       {props.t(
         "The operator is the person or people, charity or company who makes the decisions about the food business. They decide what it serves and how it operates."

--- a/pages/operator-type.js
+++ b/pages/operator-type.js
@@ -32,6 +32,7 @@ const OperatorType = (props) => (
           </Fieldset.Legend>
           <HiddenTextAccessible
             summary={props.t("What is a food business operator?")}
+            {...props}
           >
             <Paragraph mb={0}>
               {props.t(

--- a/pages/partner-name.js
+++ b/pages/partner-name.js
@@ -68,7 +68,7 @@ const PartnerName = (props) => (
         )}
       </HintText>
     </ContentItem.B_30_15>
-    <PartnershipDescription />
+    <PartnershipDescription {...props} />
     <PostForm
       action={props.partnerDetailsDeleteFormAction}
       csrfToken={props.csrfToken}

--- a/pages_unit_tests/operator-address.test.js
+++ b/pages_unit_tests/operator-address.test.js
@@ -49,13 +49,6 @@ describe("<OperatorAddress />", () => {
         "Partnership address is the contact address for the partner who is the main point of contact."
       );
     });
-
-    it("renders correct hidden text", () => {
-      const hiddenText = wrapper.find(Paragraph);
-      expect(hiddenText.at(1).props().children).toBe(
-        "In a partnership, you and your partner (or partners) personally share responsibility for your food business"
-      );
-    });
   });
   describe("Operator postcode input field", () => {
     it("renders", () => {

--- a/src/components/AddressHelp.js
+++ b/src/components/AddressHelp.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { ContentItem } from "../../src/components";
 import { Heading, HintText } from "govuk-react";
-import { PartnershipDescription, OperatorDescription } from "./";
 import { withTranslation } from "../../i18n.js";
 import { operatorTypeEnum } from "@slice-and-dice/register-a-food-business-validation";
 
@@ -18,7 +17,6 @@ const AddressHelp = (props) => {
           )}
         </HintText>
       </ContentItem.B_30_15>
-      <PartnershipDescription />
     </React.Fragment>
   ) : (
     <React.Fragment>
@@ -32,7 +30,6 @@ const AddressHelp = (props) => {
           )}
         </HintText>
       </ContentItem.B_30_15>
-      <OperatorDescription />
     </React.Fragment>
   );
 };

--- a/src/components/ContactDetailsHelp.js
+++ b/src/components/ContactDetailsHelp.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { ContentItem } from "../../src/components";
 import { HintText } from "govuk-react";
-import { PartnershipDescription, OperatorDescription } from "./";
+import { OperatorDescription } from "./";
 import { withTranslation } from "../../i18n.js";
 import { operatorTypeEnum } from "@slice-and-dice/register-a-food-business-validation";
 
@@ -19,10 +19,9 @@ const ContactDetailsHelp = (props) => {
   return props.role === operatorTypeEnum.PARTNERSHIP.key ? (
     <React.Fragment>
       <PartnershipHintText t={props.t} />
-      <PartnershipDescription />
     </React.Fragment>
   ) : (
-    <OperatorDescription />
+    <OperatorDescription {...props} />
   );
 };
 

--- a/src/components/HiddenTextAccessible.js
+++ b/src/components/HiddenTextAccessible.js
@@ -2,22 +2,36 @@ import { Details } from "govuk-react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import { withTranslation } from "../../i18n.js";
+import InsetText from "./InsetText";
 
 const StyledDiv = styled("div")`
   margin-bottom: 30px;
 `;
 
-const HiddenTextAccessible = (props) => (
-  <StyledDiv>
-    <Details
-      summary={props.summary}
-      mb={0}
-      aria-label={props.t("Additional information")}
-    >
-      {props.children}
-    </Details>
-  </StyledDiv>
-);
+const HiddenTextAccessible = (props) => {
+  return (
+    <>
+      {props.browser === "IE" || props.browser === "Edge" ? (
+        <StyledDiv>
+          <InsetText aria-label={props.t("Additional information")}>
+            <p class="bold">{props.summary}</p>
+            <p>{props.children}</p>
+          </InsetText>
+        </StyledDiv>
+      ) : (
+        <StyledDiv>
+          <Details
+            summary={props.summary}
+            mb={0}
+            aria-label={props.t("Additional information")}
+          >
+            {props.children}
+          </Details>
+        </StyledDiv>
+      )}
+    </>
+  );
+};
 
 HiddenTextAccessible.defaultProps = {
   hiddentextindex: 0

--- a/src/components/OpeningDate.js
+++ b/src/components/OpeningDate.js
@@ -34,6 +34,7 @@ const OpeningDate = (props) => {
         hiddentextindex={1}
         id="hiddenTextEstablishment"
         summary={props.t("What is an establishment?")}
+        {...props}
       >
         <Paragraph mb={0}>
           {props.t(
@@ -77,6 +78,7 @@ const OpeningDate = (props) => {
                 summary={props.t(
                   "I don't know when this establishment will begin trading"
                 )}
+                {...props}
               >
                 <Paragraph mb={0}>
                   {props.t(
@@ -121,6 +123,7 @@ const OpeningDate = (props) => {
               summary={props.t(
                 "I don't know when this establishment began trading"
               )}
+              {...props}
             >
               <Paragraph mb={0}>
                 {props.t(

--- a/src/components/OperatorDescription.js
+++ b/src/components/OperatorDescription.js
@@ -3,7 +3,10 @@ import { Paragraph } from "govuk-react";
 import { withTranslation } from "../../i18n.js";
 
 const OperatorDescription = (props) => (
-  <HiddenTextAccessible summary={props.t("What is a food business operator?")}>
+  <HiddenTextAccessible
+    summary={props.t("What is a food business operator?")}
+    {...props}
+  >
     <Paragraph mb={0}>
       {props.t(
         "The operator is the person or people, charity or company who makes the decisions about the food business. They decide what it serves and how it operates."

--- a/src/components/PartnershipDescription.js
+++ b/src/components/PartnershipDescription.js
@@ -3,7 +3,7 @@ import { Paragraph } from "govuk-react";
 import { withTranslation } from "../../i18n.js";
 
 const PartnershipDescription = (props) => (
-  <HiddenTextAccessible summary={props.t("What is a partnership?")}>
+  <HiddenTextAccessible summary={props.t("What is a partnership?")} {...props}>
     <Paragraph mb={0}>
       {props.t(
         "In a partnership, you and your partner (or partners) personally share responsibility for your food business"


### PR DESCRIPTION
`<details>` is a HTML5 element that is not supported by IE and Edge.  Therefore, switch to use inset text instead on those browsers.