### PR TITLE
new page added and registration updated

### DIFF
--- a/pages/partnership-contact-details.njk
+++ b/pages/partnership-contact-details.njk
@@ -1,0 +1,113 @@
+{% from "../node_modules/govuk-frontend/dist/govuk/components/button/macro.njk" import govukButton %}
+{% from "../node_modules/govuk-frontend/dist/govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "../node_modules/govuk-frontend/dist/govuk/components/details/macro.njk" import govukDetails %}
+{% from "../node_modules/govuk-frontend/dist/govuk/components/input/macro.njk" import govukInput %}
+{% from "../node_modules/govuk-frontend/dist/govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "../components/PostForm.njk" import postForm %}
+{% from "../components/ProcessedErrorSummary.njk" import processedErrorSummary %}
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% call postForm(props.formAction, props.csrfToken, props.language) -%}
+      {{ processedErrorSummary(props.validatorErrors, props.language) }}
+        {% call govukFieldset({
+      legend: {
+        text: __("Partnership details", props.language),
+        classes: "govuk-fieldset__legend--l",
+        isPageHeading: true
+              }
+      }) %}
+        {% endcall %}
+      {{ govukDetails({
+    summaryText: __("What is a food business operator?", props.language),
+    text: __("The operator is the person or people, charity or company who makes the decisions about the food business. They decide what it serves and how it operates.", props.language)
+  }) }}
+                                                              
+        {% call govukDateInput({
+                  id: "operator_birthdate",
+                  namePrefix: "operator_birthdate",
+                  fieldset: {
+                    legend: {
+                      text: __("What is the main partners birthdate?", props.language),
+                      classes: "govuk-label--s"
+                    }
+                  },
+                  hint: {
+                     text: __("For example, 31 03 1980", props.language)
+                   },
+                  items: [
+                    {
+                      id: "day",
+                      name: "day",
+                      label: __('Day', props.language),
+                      classes: "govuk-input--width-2",
+                      value: props.cumulativeFullAnswers.operator_birthdate_day
+                    },
+                    {
+                     id: "month",
+                      name: "month",
+                      label: __('Month', props.language),
+                      classes: "govuk-input--width-2",
+                      value: props.cumulativeFullAnswers.operator_birthdate_month
+                    },
+                    {
+                     id: "year",
+                      name: "year",
+                      label: __('Year', props.language),
+                      classes: "govuk-input--width-4",
+                      value: props.cumulativeFullAnswers.operator_birthdate_year
+                    }
+                  ],
+                  errorMessage: { 
+                    text: __(props.validatorErrors.operator_birthdate, props.language) 
+                  } if props.validatorErrors.operator_birthdate
+                }) %}
+        {% endcall %}
+                                                        
+      {{ govukInput({
+      "label": {
+        "text": __("Main phone number", props.language)
+      },
+      "id": "operator_primary_number",
+      "name": "operator_primary_number",
+      "value": props.cumulativeFullAnswers.operator_primary_number,
+      "classes": "govuk-label--l",
+      "autoComplete": "tel",
+       "errorMessage": {
+      "text":  __(props.validatorErrors.operator_primary_number, props.language) } if props.validatorErrors.operator_primary_number       
+   }) }}
+      {{ govukInput({
+      "label": {
+        "text": __("Secondary phone number (optional)", props.language)
+      },
+      "id": "operator_secondary_number",
+      "name": "operator_secondary_number",
+      "value": props.cumulativeFullAnswers.operator_secondary_number,
+      "classes": "govuk-label--l",
+      "autoComplete": "off",
+      "errorMessage": {
+      "text":  __(props.validatorErrors.operator_secondary_number, props.language) } if props.validatorErrors.operator_secondary_number 
+  }) }}
+      {{ govukInput({
+      "label": {
+        "text": __("Email address", props.language)
+      },
+      "hint": {
+      "text": __("We will use your email address to send a copy of your registration details. The food safety team at your local authority may contact you with additional guidance and support and to obtain further information if required.", props.language)
+      },
+      "id": "operator_email",
+      "name": "operator_email",
+      "value": props.cumulativeFullAnswers.operator_email,
+      "classes": "govuk-label--l",
+      "autoComplete": "email",
+      "errorMessage": {
+      "text": __(props.validatorErrors.operator_email, props.language) } if props.validatorErrors.operator_email
+  }) }}
+      {{ govukButton({
+        text: __("Save and continue", props.language) if props.editModeFirstPage else __("Continue", props.language)
+      }) }}
+      {% endcall %}
+    </div>
+  </div>
+{% endblock %}

--- a/pages/registration-summary.njk
+++ b/pages/registration-summary.njk
@@ -46,6 +46,9 @@ summaryListDeclarationHelper %}
           <span id="operator_last_name">{{ (propsData.operator_last_name if propsData.operator_last_name else "") }}</span>
         </div>
         {% endset %}
+          {% if propsData.applicationCompletePage == null %}
+            {{ summaryListHelper(__("Operators Birthdate", props.language), propsData.operator_birthdate, "/edit/operator-birthdate", propsData.operator_birthdate, "operator_birthdate", props) }}
+        {% endif %}
         {% if props.cumulativeFullAnswers.registration_role === "SOLETRADER" or props.cumulativeFullAnswers.operator_type === "PERSON" %}
           {{ summaryListHelperHtml(__("Name", props.language), html, "/edit/operator-name", propsData.operator_first_name and propsData.operator_last_name, "operator-name", props ) }}
         {% endif %}


### PR DESCRIPTION
Added partnership other details page and updated registration summary. no need to change data ids as its impossible for operator-contact-details and partnership-contact-details to be accessed on the same registration and so the summary will take the available ids