### PR TITLE
Use longitude and latitude instead of grideasting and gridnorthing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "register_a_food_business_front_end",
-  "version": "15.2.1",
+  "version": "16.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "register_a_food_business_front_end",
-      "version": "15.2.1",
+      "version": "16.1.0",
       "dependencies": {
         "@ons/design-system": "^67.0.3",
         "@slice-and-dice/register-a-food-business-validation": "^1.29.4",

--- a/src/server/connectors/local-authority-lookup/local-authority-lookup-api.connector.js
+++ b/src/server/connectors/local-authority-lookup/local-authority-lookup-api.connector.js
@@ -69,28 +69,27 @@ const getLocalAuthorityIDByPostcode = async (postcode, generation) => {
 };
 
 /**
- * Fetches Local authority id from the local authority lookup API for the given grideasting and gridnorthing point
- * @param {string} grideasting The easting to search by
- * @param {string} gridnorthing The northing to search by
+ * Fetches Local authority id from the local authority lookup API for the given longitude and latitude point
+ * @param {string} longitude The longitude to search by
+ * @param {string} latitude The latitude to search by
  * @param {integer} generation The generayion number (optional)
  * @returns {integer} Local authority id
  */
-const getLocalAuthorityIDByPoint = async (grideasting, gridnorthing, generation) => {
+const getLocalAuthorityIDByPoint = async (longitude, latitude, generation) => {
   logEmitter.emit(
     "functionCallWith",
     "local-authority-lookup-api.connector",
     "getLocalAuthorityIDByPoint",
-    `${grideasting},${gridnorthing}`
+    `${longitude},${latitude}`
   );
 
   let responseJSON;
   let localAuthority;
 
-  responseJSON = await fetchUsingMapItPointApi(grideasting, gridnorthing, generation);
+  responseJSON = await fetchUsingMapItPointApi(longitude, latitude, generation);
 
   if (responseJSON && Object.keys(responseJSON).length > 0) {
-    // check if any object has one of this type 'MTD', 'DIS','UTA', 'CTY','LGD', 'LBO','COI' and return id
-    // DIS and CTY can be in the same response
+    // check if any object has one of this type 'MTD', 'DIS','UTA','LGD', 'LBO','COI' and return id
     const validTypes = ["MTD", "DIS", "UTA", "LGD", "LBO", "COI"];
     for (const key in responseJSON) {
       if (responseJSON.hasOwnProperty(key)) {
@@ -189,18 +188,18 @@ const fetchUsingMapItApi = async (postcode, generation) => {
 
 /**
  * Fetches local authority using MapIt Point service
- * @param {string} grideasting The easting to search by
- * @param {string} gridnorthing The northing to search by
+ * @param {string} longitude The longitude to search by
+ * @param {string} latitude The northing to search by
  * @param {integer} generation The generayion number (optional)
  * @returns {object} API response object
  */
-const fetchUsingMapItPointApi = async (grideasting, gridnorthing, generation) => {
+const fetchUsingMapItPointApi = async (longitude, latitude, generation) => {
   try {
     logEmitter.emit(
       "functionCallWith",
       "local-authority-lookup-api.connector",
       "fetchUsingMapItPointApi",
-      `${grideasting},${gridnorthing}`
+      `${longitude},${latitude}`
     );
 
     let mapitGeneration = generation ? `&generation=${generation}` : "";
@@ -212,7 +211,7 @@ const fetchUsingMapItPointApi = async (grideasting, gridnorthing, generation) =>
       options.proxy = false;
     }
     const response = await axios(
-      `${MAPIT_API}/point/27700/${grideasting},${gridnorthing}?api_key=${MAPIT_API_KEY}${mapitGeneration}`,
+      `${MAPIT_API}/point/4326/${longitude},${latitude}?api_key=${MAPIT_API_KEY}${mapitGeneration}`,
       options
     );
 

--- a/src/server/controllers/find-local-authority.controller.js
+++ b/src/server/controllers/find-local-authority.controller.js
@@ -60,8 +60,8 @@ const findLocalAuthorityController = async (
     if (newAnswers.establishment_address_selected) {
       const address = establishmentPostcodeFind[+newAnswers.establishment_address_selected];
 
-      if (address.grideasting && address.gridnorthing) {
-        localAuthority = await getLocalAuthorityByPoint(address.grideasting, address.gridnorthing);
+      if (address.longitude && address.latitude) {
+        localAuthority = await getLocalAuthorityByPoint(address.longitude, address.latitude);
       }
     }
 

--- a/src/server/services/local-authority.service.js
+++ b/src/server/services/local-authority.service.js
@@ -113,19 +113,19 @@ const getLocalAuthorityByPostcode = async (postcode) => {
     return false;
   }
 };
-const getLocalAuthorityByPoint = async (grideasting, gridnorthing) => {
+const getLocalAuthorityByPoint = async (longitude, latitude) => {
   logEmitter.emit("functionCall", "local-authority.service", "getLocalAuthorityByPoint");
   let localAuthorityMapitID, councilRecord;
 
   try {
     // Get the mapIt ID based on the postcode
-    localAuthorityMapitID = await getLocalAuthorityIDByPoint(grideasting, gridnorthing);
+    localAuthorityMapitID = await getLocalAuthorityIDByPoint(longitude, latitude);
     if (!localAuthorityMapitID) {
       logEmitter.emit(
         "functionFail",
         "local-authority.service",
         "getLocalAuthorityByPoint",
-        `getLocalAuthorityIDByPoint(${grideasting},${gridnorthing}) failed`
+        `getLocalAuthorityIDByPoint(${longitude},${latitude}) failed`
       );
       return false;
     }
@@ -160,8 +160,8 @@ const getLocalAuthorityByPoint = async (grideasting, gridnorthing) => {
     if (councilRecord.mapit_generation) {
       // Obtain the mapIt ID based on the point and generation ID (SECOND REQUEST)
       localAuthorityMapitID = await getLocalAuthorityIDByPoint(
-        grideasting,
-        gridnorthing,
+        longitude,
+        latitude,
         councilRecord.mapit_generation
       );
       if (!localAuthorityMapitID) {
@@ -169,7 +169,7 @@ const getLocalAuthorityByPoint = async (grideasting, gridnorthing) => {
           "functionFail",
           "local-authority.service",
           "getLocalAuthorityByPoint",
-          `getLocalAuthorityIDByPoint(${postcode}) failed`
+          `getLocalAuthorityIDByPoint(${longitude},${latitude}) failed`
         );
         return false;
       }


### PR DESCRIPTION
Refactor local authority lookup API connector to use longitude and latitude instead of grideasting and gridnorthing