### PR TITLE
checkboxes now appearing as expected

### DIFF
--- a/pages/opening-days-some.njk
+++ b/pages/opening-days-some.njk
@@ -38,43 +38,50 @@
             value: "Monday",
             id: "opening_day_monday",
             name: "opening_day_monday",
-            text: __("Monday", props.language)
+            text: __("Monday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_monday
             },
             {
             value: "Tuesday",
             id: "opening_day_tuesday",
             name: "opening_day_tuesday",
-            text: __("Tuesday", props.language)
+            text: __("Tuesday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_tuesday
             },
             {
             value: "Wednesday",
             id: "opening_day_wednesday",
             name: "opening_day_wednesday",
-            text: __("Wednesday", props.language)
+            text: __("Wednesday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_wednesday
             },
             {
             value: "Thursday",
             id: "opening_day_thursday",
             name: "opening_day_thursday",
-            text: __("Thursday", props.language)
+            text: __("Thursday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_thursday
             },
             {
             value: "Friday",
             id: "opening_day_friday",
             name: "opening_day_friday",
-            text: __("Friday", props.language)
+            text: __("Friday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_friday
             },
             {
             value: "Saturday",
             id: "opening_day_saturday",
             name: "opening_day_saturday",
-            text: __("Saturday", props.language)
+            text: __("Saturday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_saturday
             },
             {
             value: "Sunday",
             id: "opening_day_sunday",
             name: "opening_day_sunday",
-            text: __("Sunday", props.language)
+            text: __("Sunday", props.language),
+            checked: props.cumulativeFullAnswers.opening_day_sunday
             }
         ]
         }) }}


### PR DESCRIPTION
Checkboxes now appear populated if they were set fpreviously by user in the edit route