### PR TITLE
Remove unselected opening hours entries on navigation

### DIFF
--- a/src/server/controllers/edit.controller.js
+++ b/src/server/controllers/edit.controller.js
@@ -160,15 +160,7 @@ const editContinue = (
     // If we're coming from the opening-days-some page, remove any opening_hours_{day}
     // entries for days that are no longer selected in the edited answers.
     if (currentPage === "/opening-days-some") {
-      const DAYS = [
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-        "sunday"
-      ];
+      const DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
       const cumulFull = newCumulativeFullAnswers;
       const cumulEdit = newCumulativeEditAnswers;
 


### PR DESCRIPTION
Eliminate opening hours entries for days that are no longer selected when navigating from the opening-days-some page.