### PR TITLE
Handle missing Referrer header in partner and trading name routing 

### DIFF
--- a/src/server/propsGenerator.js
+++ b/src/server/propsGenerator.js
@@ -85,13 +85,13 @@ module.exports = (req) => {
       : "/tradingname/continue/establishment-trading-name";
 
   const partnerDetailsSaveFormAction = editModePartnerDetails
-    ? "/partnership/save/partner-name?edit=partner-name"
-    : "/partnership/save/partner-name";
+    ? "/partnership/save/partner-details?edit=partner-name"
+    : "/partnership/save/partner-details";
 
   const tradingNameDetailsSaveFormAction =
     req && req.query && req.query.edit
-      ? "/tradingname/save/establishment-trading-name?edit=establishment-trading-name"
-      : "/tradingname/save/establishment-trading-name";
+      ? "/tradingname/save/establishment-trading-name-details?edit=establishment-trading-name"
+      : "/tradingname/save/establishment-trading-name-details";
 
   const partnerDetailsBackUrl = editModePartnerDetails
     ? "/partnership/back?edit=partner-name"

--- a/src/server/propsGenerator.js
+++ b/src/server/propsGenerator.js
@@ -67,31 +67,31 @@ module.exports = (req) => {
       : "/tradingname/establishment-trading-name-details";
 
   const partnerDetailsDeleteFormAction = editModePartnerDetails
-    ? "/partnership/delete-partner?edit=partner-name"
-    : "/partnership/delete-partner";
+    ? "/partnership/delete-partner/partner-name?edit=partner-name"
+    : "/partnership/delete-partner/partner-name";
 
   const tradingNameDetailsDeleteFormAction =
     req && req.query && req.query.edit
-      ? "/tradingname/delete-trading-name?edit=establishment-trading-name"
-      : "/tradingname/delete-trading-name";
+      ? "/tradingname/delete-trading-name/establishment-trading-name?edit=establishment-trading-name"
+      : "/tradingname/delete-trading-name/establishment-trading-name";
 
   const partnerDetailsContinueFormAction = editModePartnerDetails
-    ? "/partnership/continue?edit=partner-name"
-    : "/partnership/continue";
+    ? "/partnership/continue/partner-name?edit=partner-name"
+    : "/partnership/continue/partner-name";
 
   const tradingNameDetailsContinueFormAction =
     req && req.query && req.query.edit
-      ? "/tradingname/continue?edit=establishment-trading-name"
-      : "/tradingname/continue";
+      ? "/tradingname/continue/establishment-trading-name?edit=establishment-trading-name"
+      : "/tradingname/continue/establishment-trading-name";
 
   const partnerDetailsSaveFormAction = editModePartnerDetails
-    ? "/partnership/save?edit=partner-name"
-    : "/partnership/save";
+    ? "/partnership/save/partner-name?edit=partner-name"
+    : "/partnership/save/partner-name";
 
   const tradingNameDetailsSaveFormAction =
     req && req.query && req.query.edit
-      ? "/tradingname/save?edit=establishment-trading-name"
-      : "/tradingname/save";
+      ? "/tradingname/save/establishment-trading-name?edit=establishment-trading-name"
+      : "/tradingname/save/establishment-trading-name";
 
   const partnerDetailsBackUrl = editModePartnerDetails
     ? "/partnership/back?edit=partner-name"

--- a/src/server/routes/partner-details.route.js
+++ b/src/server/routes/partner-details.route.js
@@ -12,10 +12,6 @@ const {
   partnerDetailsDelete
 } = require("../controllers/partner-details.controller");
 
-const getOriginator = (referrerUrl) => {
-  return referrerUrl.substr(referrerUrl.lastIndexOf("/")).split("?")[0];
-};
-
 const isEditMode = (reqQuery) => {
   return reqQuery.edit === "partner-name";
 };
@@ -29,10 +25,10 @@ const PropsGenerator = require("../propsGenerator");
 const partnerDetailsRouter = () => {
   const router = Router();
 
-  router.post("/save", async (req, res, next) => {
+  router.post("/save/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/partnership/save route");
     try {
-      const originator = getOriginator(req.get("Referrer"));
+      const originator = `/${req.params.originator}`;
 
       const data =
         req.session.cumulativeFullAnswers.targetPartner !== undefined
@@ -90,7 +86,7 @@ const partnerDetailsRouter = () => {
     });
   });
 
-  router.post("/delete-partner", async (req, res, next) => {
+  router.post("/delete-partner/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/partnership/delete-partner route");
     try {
       req.session.cumulativeFullAnswers.partners = initializePartners(req.session);
@@ -118,10 +114,10 @@ const partnerDetailsRouter = () => {
     }
   });
 
-  router.post("/continue", async (req, res, next) => {
+  router.post("/continue/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/partnership/continue route");
     try {
-      const originator = getOriginator(req.get("Referrer"));
+      const originator = `/${req.params.originator}`;
 
       req.session.cumulativeFullAnswers.partners = initializePartners(req.session);
 

--- a/src/server/routes/partner-details.route.test.js
+++ b/src/server/routes/partner-details.route.test.js
@@ -21,6 +21,7 @@ describe("Partner Details Route: ", () => {
 
   describe("POST to /save", () => {
     let req, res;
+    let next = jest.fn();
     describe("Add new partner", () => {
       beforeEach(() => {
         partnerDetailsSave.mockImplementation(() => ({
@@ -46,6 +47,9 @@ describe("Partner Details Route: ", () => {
               cb();
             }
           },
+          params: {
+            originator: "thepage"
+          },
           csrfToken: jest.fn(),
           url: "test/test",
           get: (value) => "www.test.com/new/thepage?display=true",
@@ -58,7 +62,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
 
       it("Should return the correct response", () => {
@@ -88,7 +92,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: { targetPartner: "Brian May" },
@@ -105,6 +109,9 @@ describe("Partner Details Route: ", () => {
           header: {
             Referrer: "www.test.com/new/thepage?display=true"
           },
+          params: {
+            originator: "thepage"
+          },
           query: {}
         };
 
@@ -113,7 +120,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
 
       it("Should return the correct response", () => {
@@ -196,7 +203,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: {},
@@ -213,6 +220,9 @@ describe("Partner Details Route: ", () => {
           header: {
             Referrer: "www.test.com/new/thepage?display=true"
           },
+          params: {
+            originator: "thepage"
+          },
           body: "body",
           query: {}
         };
@@ -222,7 +232,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
 
       it("Should have response contain partners set as empty array", () => {
@@ -244,7 +254,7 @@ describe("Partner Details Route: ", () => {
       let res, req;
       beforeEach(() => {
         handler = router.get.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: {
@@ -266,7 +276,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
 
       it("Should set target partner to have a value", () => {
@@ -284,7 +294,7 @@ describe("Partner Details Route: ", () => {
       let res, req;
       beforeEach(() => {
         handler = router.get.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: {},
@@ -302,7 +312,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
 
       it("Should delete target partner", () => {
@@ -320,7 +330,7 @@ describe("Partner Details Route: ", () => {
       let res, req;
       beforeEach(() => {
         handler = router.get.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: {
@@ -341,7 +351,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
       it("Should delete target partner", () => {
         expect(req.session.cumulativeFullAnswers.targetPartner).toBe(undefined);
@@ -355,7 +365,7 @@ describe("Partner Details Route: ", () => {
       let res, req, response;
       beforeEach(() => {
         handler = router.get.mock.calls[0][1];
-
+        let next = jest.fn();
         req = {
           session: {
             cumulativeFullAnswers: {
@@ -378,7 +388,7 @@ describe("Partner Details Route: ", () => {
         };
 
         try {
-          handler(req, res);
+          handler(req, res, next);
         } catch (err) {
           response = err;
         }
@@ -404,7 +414,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[1][1];
-
+        let next = jest.fn();
         req = {
           session: {
             council: "council",
@@ -432,7 +442,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
       it("Should call the partner details controller correctly", () => {
         expect(partnerDetailsDelete).toHaveBeenCalledWith(
@@ -456,7 +466,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[1][1];
-
+        let next = jest.fn();
         req = {
           session: {
             council: "council",
@@ -482,7 +492,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
       it("Should call the partner details controller correctly", () => {
         expect(partnerDetailsDelete).toHaveBeenCalledWith(
@@ -531,6 +541,9 @@ describe("Partner Details Route: ", () => {
           header: {
             Referrer: "www.address.com/new/council/thispage?blah=hello"
           },
+          params: {
+            originator: "thepage"
+          },
           query: {}
         };
 
@@ -565,7 +578,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[2][1];
-
+        let next = jest.fn();
         req = {
           session: {
             council: "council",
@@ -583,6 +596,9 @@ describe("Partner Details Route: ", () => {
           body: {
             example: "property to ignore"
           },
+          params: {
+            originator: "thepage"
+          },
           header: {
             Referrer: "www.address.com/new/council/thispage?blah=hello"
           },
@@ -593,7 +609,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
       it("Should call the partnerDetailsContinue correctly", () => {
         expect(partnerDetailsContinue).toHaveBeenCalledWith(
@@ -618,7 +634,7 @@ describe("Partner Details Route: ", () => {
         }));
 
         handler = router.post.mock.calls[2][1];
-
+        let next = jest.fn();
         req = {
           session: {
             council: "council",
@@ -634,6 +650,9 @@ describe("Partner Details Route: ", () => {
           body: {
             example: "property"
           },
+          params: {
+            originator: "thepage"
+          },
           header: {
             Referrer: "www.address.com/new/council/thispage?blah=hello"
           },
@@ -645,7 +664,7 @@ describe("Partner Details Route: ", () => {
           render: jest.fn()
         };
 
-        handler(req, res);
+        handler(req, res, next);
       });
       it("Should call the partnerDetailsContinue correctly", () => {
         expect(partnerDetailsContinue).toHaveBeenCalledWith(
@@ -692,6 +711,9 @@ describe("Partner Details Route: ", () => {
           body: {
             example: "property"
           },
+          params: {
+            originator: "thepage"
+          },
           header: {
             Referrer: "www.address.com/new/council/thispage?blah=hello"
           },
@@ -734,6 +756,9 @@ describe("Partner Details Route: ", () => {
             save: (cb) => {
               cb();
             }
+          },
+          params: {
+            originator: "thepage"
           },
           csrfToken: jest.fn(),
           url: "test/test",
@@ -816,6 +841,9 @@ describe("Partner Details Route: ", () => {
           get: () => "www.test.com/new/thepage?display=true",
           body: {
             example: "property"
+          },
+          params: {
+            originator: "thepage"
           },
           header: {
             Referrer: "www.address.com/new/council/thispage?blah=hello"

--- a/src/server/routes/trading-name-details.route.js
+++ b/src/server/routes/trading-name-details.route.js
@@ -13,10 +13,6 @@ const {
   tradingNameDetailsContinue
 } = require("../controllers/trading-name-details.controller");
 
-const getOriginator = (referrerUrl) => {
-  return referrerUrl.substr(referrerUrl.lastIndexOf("/")).split("?")[0];
-};
-
 const isEditMode = (reqQuery) => {
   return reqQuery.edit === "establishment-trading-name";
 };
@@ -30,10 +26,10 @@ const PropsGenerator = require("../propsGenerator");
 const tradingNameDetailsRouter = () => {
   const router = Router();
 
-  router.post("/save", async (req, res, next) => {
+  router.post("/save/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/tradingname/save route");
     try {
-      const originator = getOriginator(req.get("Referrer"));
+      const originator = `/${req.params.originator}`;
 
       const data = req.session.cumulativeFullAnswers.targetTradingName
         ? Object.assign({}, req.body, {
@@ -115,7 +111,7 @@ const tradingNameDetailsRouter = () => {
     });
   });
 
-  router.post("/delete-trading-name", async (req, res, next) => {
+  router.post("/delete-trading-name/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/tradingname/delete-trading-name route");
     try {
       req.session.cumulativeFullAnswers.establishment_additional_trading_names =
@@ -144,10 +140,10 @@ const tradingNameDetailsRouter = () => {
     }
   });
 
-  router.post("/continue", async (req, res, next) => {
+  router.post("/continue/:originator", async (req, res, next) => {
     logEmitter.emit("functionCall", "Routes", "/tradingname/continue route");
     try {
-      const originator = getOriginator(req.get("Referrer"));
+      const originator = `/${req.params.originator}`;
 
       req.session.cumulativeFullAnswers = req.session.cumulativeFullAnswers || {};
       req.session.cumulativeFullAnswers.establishment_additional_trading_names =


### PR DESCRIPTION
This standardises the partner and trading details routes to use the request URL route to get the originator, rather than using the Referrer header which seems to be unreliable in production: possibly some browsers or firewalls are stripping it out on occasion, leading to errors in the application which then trigger alerts.

The unit tests have been updated accordingly: note that a mocked next function is now passed in to ensure test failures are reported correctly. Ideally, the partner-details.route.js would be refactored at some point so that mocking so much of req, res and next was no longer required.

[Work item](https://github.com/orgs/FoodStandardsAgency/projects/28/views/4?pane=issue&itemId=164282288&issue=FoodStandardsAgency%7Cdsm-service%7C52)